### PR TITLE
Add graceful shutdown capability

### DIFF
--- a/test_hey.sh
+++ b/test_hey.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
 
 hey -n 100000 http://localhost:8080/
+
+# -t 0 infinite timeout
+# -c 2 two concurrent clients
+# -n total number of requests to make
+hey -t 0 -c 2 -n 20 http://localhost:8080/


### PR DESCRIPTION
Add signal handling and make use of context to shutdown gracefully.

Tested by making slowResponse > shutdown_wait first (to confirm that it
killed long running requests) and then with slowResponse < shutdown_wait
(to confirm that it exited when connections had finished up).

Need to figure out how to add this to the unit tests.

Issue(s): None